### PR TITLE
Handle pending profile responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 yarn.lock
 ./node_modules/
 index.html
+!frontend/index.html
 script.js
 style.css
 IMG_20240703_152420.png

--- a/FIX_PLAN.md
+++ b/FIX_PLAN.md
@@ -1,0 +1,36 @@
+# Remediation Plan
+
+This project has a solid ingestion pipeline and UI shell, but production issues span configuration, GitHub API usage, data modeling, caching and front-end/back-end contracts. The plan below is organized to tackle the highest-risk bugs first and then deliver feature parity between the services and UI.
+
+## Phase 1 – Stabilize the backend
+1. **Configuration hardening**
+   - Provide safe defaults for optional environment variables and guard required ones with helpful error messages.
+   - Allow the API to boot without TLS-only database/Redis settings so local development works out of the box.
+2. **GitHub client reliability**
+   - Rotate tokens on every request (not just module load) and recover gracefully from missing token pools.
+   - Tighten rate-limit handling so requests are retried with the next token or fail fast with context.
+3. **Ranking data correctness**
+   - Persist follower and public repository counts with each ranking snapshot and use those values in the “should update” check.
+   - Import the GitHub service where needed and ensure ranking updates no longer throw due to missing fields.
+4. **Cache invalidation fixes**
+   - Replace wildcard `redisClient.del` usage with a helper that scans keys by pattern before deleting them.
+
+## Phase 2 – Align API contracts with UI needs
+5. **Repository DTO parity**
+   - Expose only the fields we actually capture (stars, forks, issues, topics, last commit, commit totals) and update the React components to match.
+   - Extend persistence if additional metrics (license, size, language) are required.
+6. **Ranking endpoint & UI integration**
+   - Return a consistent ranking response (global rank, country rank, score, totals) from the backend.
+   - Update the front-end ranking component to fetch real data and show loading/error states.
+7. **Activity aggregates**
+   - Provide aggregate stats (total contributions, current streak) or adjust the UI to visualize the time-series that exists today.
+
+## Phase 3 – Polish & documentation
+8. **Environment documentation**
+   - Document required env vars, defaults, and sample `.env` files for local development.
+9. **Testing coverage**
+   - Add integration tests that exercise the ranking refresh flow and API contracts.
+10. **UX follow-ups**
+    - Hook up About/Contact navigation, improve loading states, and surface refresh progress to users.
+
+We start executing Phase 1 in this iteration to unblock local reliability and repair the ranking pipeline, then move into Phase 2 for API/UI alignment.

--- a/README.md
+++ b/README.md
@@ -53,36 +53,58 @@ git clone https://github.com/EL-HOUSS-BRAHIM/github-api.git
 cd github-api
 ```
 
-2. Copy the example environment file:
+2. Install backend dependencies and prepare an environment file:
 ```bash
+cd my-backend-app
+npm install
 cp .env.example .env
 ```
 
-3. Configure your environment variables in `.env`:
-```
-PORT=3000
-DB_HOST=localhost
-DB_USER=your_db_user
-DB_PASSWORD=your_db_password
-DB_NAME=github_data
-GITHUB_TOKEN=your_github_token
-REDIS_HOST=localhost
-REDIS_PORT=6379
-```
+3. Update `.env` with the values that match your setup. The defaults are tuned for local MySQL + Redis deployments:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | HTTP port used by the Express API |
+| `DB_HOST` | `127.0.0.1` | MySQL host name |
+| `DB_PORT` | `3306` | MySQL port |
+| `DB_USER` | `root` | Database user for the ingestion schema |
+| `DB_PASSWORD` | _(blank)_ | Password for `DB_USER` |
+| `DB_NAME` | `github_insights` | Database name used by Sequelize |
+| `DB_SSL_CA_PATH` | _(blank)_ | Optional absolute path to a CA certificate when connecting over TLS |
+| `DB_SSL_REJECT_UNAUTHORIZED` | `true` | Set to `false` to skip certificate validation in non-production environments |
+| `GITHUB_TOKENS` | _(blank)_ | Comma separated list of GitHub personal access tokens used for rate-limit rotation |
+| `REDIS_HOST` | `127.0.0.1` | Redis hostname |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_USERNAME` | _(blank)_ | Optional username when Redis ACLs are enabled |
+| `REDIS_PASSWORD` | _(blank)_ | Redis password when authentication is required |
+| `REDIS_TLS` | `false` | Set to `true` to enable TLS connections to Redis |
+
+The `.env.example` file in `my-backend-app/` documents these options for quick reference.
 
 ### Installation
 
-1. Install dependencies:
+Install backend dependencies:
 ```bash
+cd my-backend-app
 npm install
 ```
 
-2. Start the services using Docker:
+Install frontend dependencies:
 ```bash
-docker-compose up -d
+cd ../frontend
+npm install
 ```
 
-3. Run the application:
+Return to the project root when you are done installing packages.
+
+### Running locally
+
+Start the API (from `my-backend-app/`):
+```bash
+npm run dev
+```
+
+Start the Vite development server (from `frontend/`):
 ```bash
 npm run dev
 ```
@@ -103,19 +125,12 @@ Access the Swagger documentation at http://localhost:3000/api-docs
 
 ## Development
 
-Run the development server with hot reload:
-```bash
-npm run dev
-```
+### Testing
 
-Run the worker process:
+API contract tests are implemented with Jest and Supertest:
 ```bash
-no need
-```
-
-Clear Redis cache:
-```bash
-no need
+cd my-backend-app
+npm test
 ```
 
 ## Docker Support

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GitHub Insights</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,20 +6,21 @@
     "scripts": {
         "dev": "vite",
         "open": "vite --host",
-        "build": "vite build",
-        "preview": "vite preview"
-    },
-    "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.7.2",
-        "axios": "^1.6.7",
-        "react": "^18.2.0",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.24.0"
     },
     "devDependencies": {
         "@types/react": "^18.2.56",
-        "@types/react-dom": "^18.2.19",
-        "@vitejs/plugin-react": "^4.2.1",
-        "vite": "^5.2.8"
-    }
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.8"
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,8 @@ import HomePage from './components/HomePage';
 import UserProfile from './components/UserProfile';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
+import About from './components/About';
+import Contact from './components/Contact';
 
 function App() {
   return (
@@ -12,6 +14,8 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/user/:username" element={<UserProfile />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/contact" element={<Contact />} />
       </Routes>
       <Footer />
       </>

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import styles from '../styles/StaticPage.module.css';
+
+function About() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.page_header}>
+        <h1 className={styles.page_title}>About GitHub Report</h1>
+        <p className={styles.page_lead}>
+          GitHub Report brings together harvesting queues, cached analytics, and a focused user
+          experience so you can explore contribution insights without wrestling with the raw GitHub API.
+        </p>
+      </header>
+
+      <section className={styles.section}>
+        <div className={styles.section_card}>
+          <h2 className={styles.section_title}>Why we built it</h2>
+          <p className={styles.section_body}>
+            Teams, hiring managers, and open-source maintainers often need a reliable snapshot of how a developer
+            collaborates across repositories. GitHub Report automates the heavy lifting: we harvest public data,
+            normalize it across events, and calculate meaningful metrics like active streaks, contribution totals,
+            and regional rankings. The goal is to replace manual spreadsheets with a living profile that stays in sync
+            with GitHub activity.
+          </p>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_card}>
+          <h2 className={styles.section_title}>Platform highlights</h2>
+          <div className={styles.highlight_grid}>
+            <div className={styles.highlight_card}>
+              <h3 className={styles.highlight_card_title}>Contribution analytics</h3>
+              <p className={styles.highlight_card_body}>
+                Aggregate commits, pull requests, and issues into daily activity, streaks, and contribution averages
+                so you can spot momentum at a glance.
+              </p>
+            </div>
+            <div className={styles.highlight_card}>
+              <h3 className={styles.highlight_card_title}>Ranking insights</h3>
+              <p className={styles.highlight_card_body}>
+                Country-aware leaderboards pair follower counts with repository health to show how developers compare
+                locally and globally.
+              </p>
+            </div>
+            <div className={styles.highlight_card}>
+              <h3 className={styles.highlight_card_title}>Performance minded</h3>
+              <p className={styles.highlight_card_body}>
+                Redis-backed caches, Bull queues, and token rotation guard against rate limits while keeping profile
+                refreshes snappy.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_card}>
+          <h2 className={styles.section_title}>Built for curious teams</h2>
+          <p className={styles.section_body}>
+            From engineering managers monitoring onboarding to developers showcasing their open-source footprint,
+            GitHub Report delivers a single, trustworthy dashboard. The backend exposes a clean REST API, so you can
+            embed analytics into internal tooling or automate follow-up workflows with ease.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default About;

--- a/frontend/src/components/Contact.jsx
+++ b/frontend/src/components/Contact.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styles from '../styles/StaticPage.module.css';
+
+function Contact() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.page_header}>
+        <h1 className={styles.page_title}>Contact</h1>
+        <p className={styles.page_lead}>
+          Need help interpreting a report or want to suggest a feature? Reach out and we&apos;ll follow up within
+          one business day.
+        </p>
+      </header>
+
+      <section className={styles.section}>
+        <div className={styles.section_card}>
+          <h2 className={styles.section_title}>Support channels</h2>
+          <p className={styles.section_body}>
+            GitHub Report is an API-first product, so we keep our support lines close to the code. Use the options
+            below to file an issue, discuss roadmap ideas, or share feedback about the ranking and activity data sets.
+          </p>
+          <div className={styles.contact_list}>
+            <div className={styles.contact_item}>
+              <span className={styles.contact_label}>Email</span>
+              <a className={styles.contact_link} href="mailto:support@githubreport.dev">support@githubreport.dev</a>
+            </div>
+            <div className={styles.contact_item}>
+              <span className={styles.contact_label}>GitHub Issues</span>
+              <a
+                className={styles.contact_link}
+                href="https://github.com/EL-HOUSS-BRAHIM/github-api/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                github.com/EL-HOUSS-BRAHIM/github-api/issues
+              </a>
+            </div>
+            <div className={styles.contact_item}>
+              <span className={styles.contact_label}>Documentation</span>
+              <a
+                className={styles.contact_link}
+                href="https://github.com/EL-HOUSS-BRAHIM/github-api#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Project README
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_card}>
+          <h2 className={styles.section_title}>When you&apos;ll hear from us</h2>
+          <p className={styles.section_body}>
+            We triage production issues immediately and typically resolve ingestion or caching questions within 24 hours.
+            Feature requests are reviewed weekly so we can fold them into the roadmap for the next release cycle.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Contact;

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -13,9 +13,9 @@ function Footer() {
           <div className={styles.footer_section}>
             <h3>Links</h3>
             <ul>
-              <li><a href="#">Privacy Policy</a></li>
-              <li><a href="#">Terms of Service</a></li>
-              <li><a href="#">GitHub API</a></li>
+              <li><Link to="/about">About</Link></li>
+              <li><Link to="/contact">Contact</Link></li>
+              <li><a href="https://docs.github.com/en/rest" target="_blank" rel="noopener noreferrer">GitHub API</a></li>
             </ul>
           </div>
           <div className={styles.footer_section}>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import styles from '../styles/Navbar.module.css';
 
 function Navbar() {
+  const navLinkClass = ({ isActive }) => [
+    styles.nav_link,
+    isActive ? styles.nav_link_active : ''
+  ].filter(Boolean).join(' ');
+
   return (
     <header className={styles.header}>
       <nav className={styles.nav_container}>
@@ -13,9 +18,9 @@ function Navbar() {
           </Link>
         </div>
         <div className={styles.nav_links}>
-          <Link to="/" className={styles.nav_link}>Home</Link>
-          <Link to="/about" className={styles.nav_link}>About</Link>
-          <Link to="/contact" className={styles.nav_link}>Contact</Link>
+          <NavLink to="/" end className={navLinkClass}>Home</NavLink>
+          <NavLink to="/about" className={navLinkClass}>About</NavLink>
+          <NavLink to="/contact" className={navLinkClass}>Contact</NavLink>
         </div>
       </nav>
     </header>

--- a/frontend/src/components/RepoList.jsx
+++ b/frontend/src/components/RepoList.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import api from '../services/api';
 import styles from '../styles/RepoList.module.css';
+import { formatRepoDate, formatRepoSize } from '../utils/metrics';
 
 function RepoList({ username }) {
   const [repos, setRepos] = useState([]);
@@ -72,48 +73,75 @@ function RepoList({ username }) {
             </div>
 
             <div className={styles.repo_meta}>
-              <div className={styles.repo_language}>
-                <span className={styles.lang_dot} style={{ background: '#f1e05a' }}></span>
-                {repo.language || 'Unknown'}
-              </div>
               <div className={styles.repo_stats}>
                 <span className={styles.stars} title="Stars">
-                  <i className="fas fa-star"></i> {repo.stars}
+                  <i className="fas fa-star"></i> {repo.stars ?? 0}
                 </span>
                 <span className={styles.forks} title="Forks">
-                  <i className="fas fa-code-branch"></i> {repo.forks}
+                  <i className="fas fa-code-branch"></i> {repo.forks ?? 0}
                 </span>
                 <span className={styles.issues} title="Open Issues">
-                  <i className="fas fa-exclamation-circle"></i> {repo.issues}
+                  <i className="fas fa-exclamation-circle"></i> {repo.issues ?? 0}
                 </span>
-                <span className={styles.prs} title="Pull Requests">
-                  <i className="fas fa-code-pull-request"></i> {repo.pull_requests}
+                <span className={styles.commits} title="Recorded commits">
+                  <i className="fas fa-history"></i> {repo.commit_count ?? 0}
+                </span>
+                <span className={styles.watchers} title="Watchers">
+                  <i className="fas fa-eye"></i> {repo.watchers ?? 0}
                 </span>
               </div>
             </div>
 
             <div className={styles.repo_details}>
               <div className={styles.repo_detail_item}>
+                <i className="fas fa-code"></i>
+                {repo.language || 'Language unknown'}
+              </div>
+              <div className={styles.repo_detail_item}>
                 <i className="fas fa-clock"></i>
                 Last commit: {repo.last_commit ? new Date(repo.last_commit).toLocaleDateString() : 'N/A'}
               </div>
               <div className={styles.repo_detail_item}>
                 <i className="fas fa-history"></i>
-                {repo.commits} commits
+                {repo.commit_count ?? 0} commits tracked
+              </div>
+              <div className={styles.repo_detail_item}>
+                <i className="fas fa-tags"></i>
+                {repo.topics?.length ? repo.topics.join(', ') : 'No topics'}
+              </div>
+              <div className={styles.repo_detail_item}>
+                <i className="fas fa-code-branch"></i>
+                Default branch: {repo.default_branch || 'Unknown'}
               </div>
               <div className={styles.repo_detail_item}>
                 <i className="fas fa-balance-scale"></i>
-                {repo.license || 'No license'}
+                License: {repo.license || 'Not specified'}
               </div>
               <div className={styles.repo_detail_item}>
                 <i className="fas fa-database"></i>
-                {repo.size} MB
+                {formatRepoSize(repo.size)}
               </div>
-            </div>
-
-            <div className={styles.repo_dates}>
-              <span>Created: {new Date(repo.created_at).toLocaleDateString()}</span>
-              <span>Updated: {new Date(repo.updated_at).toLocaleDateString()}</span>
+              <div className={styles.repo_detail_item}>
+                <i className="fas fa-calendar-plus"></i>
+                Created: {formatRepoDate(repo.created_at)}
+              </div>
+              <div className={styles.repo_detail_item}>
+                <i className="fas fa-calendar-alt"></i>
+                Updated: {formatRepoDate(repo.updated_at)}
+              </div>
+              {repo.homepage && (
+                <div className={styles.repo_detail_item}>
+                  <i className="fas fa-link"></i>
+                  <a
+                    href={repo.homepage}
+                    className={styles.repo_detail_link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {repo.homepage}
+                  </a>
+                </div>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/components/UserActivity.jsx
+++ b/frontend/src/components/UserActivity.jsx
@@ -1,36 +1,83 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import api from '../services/api';
+import { calculateActivityMetrics } from '../utils/metrics';
 import styles from '../styles/UserActivity.module.css';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function formatLastActive(value) {
+  if (!value) {
+    return 'No activity recorded';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'No activity recorded';
+  }
+
+  const diffDays = Math.floor((Date.now() - parsed.getTime()) / DAY_IN_MS);
+
+  let relative;
+  if (diffDays <= 0) {
+    relative = 'Today';
+  } else if (diffDays === 1) {
+    relative = 'Yesterday';
+  } else {
+    relative = `${diffDays} days ago`;
+  }
+
+  const formattedDate = parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return `${relative} • ${formattedDate}`;
+}
+
+function formatDate(value) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Unknown';
+  }
+
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
 
 function UserActivity({ username }) {
   const [activity, setActivity] = useState({
-    contributions: 0,
-    repositories: 0,
-    languages: [],
+    totalContributions: 0,
+    totals: { commits: 0, pullRequests: 0, issuesOpened: 0 },
     currentStreak: 0,
     longestStreak: 0,
-    lastUpdate: null,
+    lastActivityDate: null,
+    daysTracked: 0,
+    activeDays: 0,
+    averages: { perDay: 0, perActiveDay: 0 },
+    dailyActivity: [],
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [imageError, setImageError] = useState(false);
 
   useEffect(() => {
+    if (!username) {
+      return;
+    }
+
     const fetchActivity = async () => {
       setLoading(true);
       setError(null);
       try {
         const response = await api.getUserActivity(username);
-        setActivity({
-          contributions: response.data.totalContributions || 0,
-          repositories: response.data.totalRepositories || 0,
-          languages: response.data.languages || [],
-          currentStreak: response.data.currentStreak || 0,
-          longestStreak: response.data.longestStreak || 0,
-          lastUpdate: response.data.lastUpdate,
-        });
+        setActivity(calculateActivityMetrics(response.data || {}));
+        setImageError(false);
       } catch (err) {
-        setError(err.message || 'Failed to load user activity.');
+        setError(err.response?.data?.error || err.message || 'Failed to load user activity.');
       } finally {
         setLoading(false);
       }
@@ -39,11 +86,9 @@ function UserActivity({ username }) {
     fetchActivity();
   }, [username]);
 
-  const formatDate = (date) => {
-    if (!date) return 'N/A';
-    const timeAgo = Math.floor((new Date() - new Date(date)) / (1000 * 60 * 60 * 24));
-    return timeAgo === 0 ? 'Today' : `${timeAgo} days ago`;
-  };
+  const averagePerActiveDay = Math.round(activity.averages.perActiveDay || 0);
+  const averagePerDay = Math.round(activity.averages.perDay || 0);
+  const recentActivity = activity.dailyActivity.slice(0, 14);
 
   if (loading) {
     return <div className={styles.loading_message} aria-live="polite">Loading activity...</div>;
@@ -54,73 +99,116 @@ function UserActivity({ username }) {
   }
 
   return (
-      <div>
-        <div>
-          <h2>GitHub Status</h2>
-          <div>
-            <i className="far fa-clock" aria-hidden="true"></i>
-            <span>Last Update: {formatDate(activity.lastUpdate)}</span>
-          </div>
-          <div className={styles.status_grid}>
-            <div className={styles.status_item}>
-              <span>{activity.contributions.toLocaleString()}</span>
-              <span>Contributions</span>
-            </div>
-            <div className={styles.status_item}>
-              <span>{activity.repositories.toLocaleString()}</span>
-              <span>Repositories</span>
-            </div>
-          </div>
+    <div className={styles.activity_container}>
+      <section className={styles.section}>
+        <div className={styles.section_header}>
+          <h2>Contribution overview</h2>
+          <span className={styles.section_meta}>Last active: {formatLastActive(activity.lastActivityDate)}</span>
         </div>
-  
-        <div>
-          <h2>Most Used Languages</h2>
-          <div className={styles.language_list}>
-            {activity.languages.map((lang) => (
-              <div key={lang.name} className={styles.language_item}>
-                <span 
-                  className={styles.lang_color} 
-                  style={{ background: lang.color }}
-                  aria-hidden="true"
-                ></span>
-                <span>{lang.name}</span>
-                <span>{lang.percentage}%</span>
-              </div>
-            ))}
-          </div>
-        </div>
-  
-        <div>
-          <h2>Contribution Streak</h2>
-          <div className={styles.streak_info}>
-            <div>
-              <span>{activity.currentStreak}</span>
-              <span>Current Streak</span>
-            </div>
-            <div>
-              <span>{activity.longestStreak}</span>
-              <span>Longest Streak</span>
-            </div>
-          </div>
-        </div>
-  
-        <div>
-          <h2>Contribution Graph</h2>
-          <div className={styles.contribution_graph}>
 
-            {!imageError ? (
-              <img 
-                src={`https://ghchart.rshah.org/${username}`}
-                alt={`${username}'s GitHub contribution graph`}
-                onError={() => setImageError(true)}
-              />
-            ) : (
-              <p className={styles.error_message}>Failed to load contribution graph</p>
-            )}
+        <div className={styles.summary_grid}>
+          <div className={styles.summary_card}>
+            <span className={styles.summary_label}>Total contributions</span>
+            <span className={styles.summary_value}>{activity.totalContributions.toLocaleString()}</span>
+          </div>
+          <div className={styles.summary_card}>
+            <span className={styles.summary_label}>Active days</span>
+            <span className={styles.summary_value}>{activity.activeDays.toLocaleString()}</span>
+            <span className={styles.summary_helper}>of {activity.daysTracked.toLocaleString()} tracked days</span>
+          </div>
+          <div className={styles.summary_card}>
+            <span className={styles.summary_label}>Current streak</span>
+            <span className={styles.summary_value}>{activity.currentStreak}</span>
+            <span className={styles.summary_helper}>consecutive days</span>
+          </div>
+          <div className={styles.summary_card}>
+            <span className={styles.summary_label}>Longest streak</span>
+            <span className={styles.summary_value}>{activity.longestStreak}</span>
+            <span className={styles.summary_helper}>best run</span>
           </div>
         </div>
-      </div>
-    );
-  }
-  
-  export default UserActivity;
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_header}>
+          <h3>Contribution breakdown</h3>
+        </div>
+
+        <div className={styles.breakdown_grid}>
+          <div className={styles.metric_card}>
+            <span className={styles.metric_label}>Commits</span>
+            <span className={styles.metric_value}>{activity.totals.commits.toLocaleString()}</span>
+          </div>
+          <div className={styles.metric_card}>
+            <span className={styles.metric_label}>Pull requests</span>
+            <span className={styles.metric_value}>{activity.totals.pullRequests.toLocaleString()}</span>
+          </div>
+          <div className={styles.metric_card}>
+            <span className={styles.metric_label}>Issues opened</span>
+            <span className={styles.metric_value}>{activity.totals.issuesOpened.toLocaleString()}</span>
+          </div>
+          <div className={styles.metric_card}>
+            <span className={styles.metric_label}>Avg per active day</span>
+            <span className={styles.metric_value}>{averagePerActiveDay.toLocaleString()}</span>
+            <span className={styles.metric_helper}>Avg per tracked day: {averagePerDay.toLocaleString()}</span>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_header}>
+          <h3>Recent activity</h3>
+          <span className={styles.section_meta}>Showing last {recentActivity.length} days</span>
+        </div>
+
+        {recentActivity.length === 0 ? (
+          <div className={styles.empty_state}>No contribution activity recorded yet.</div>
+        ) : (
+          <div className={styles.table_wrapper}>
+            <table className={styles.activity_table}>
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Commits</th>
+                  <th scope="col">Pull requests</th>
+                  <th scope="col">Issues opened</th>
+                  <th scope="col">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentActivity.map((day) => (
+                  <tr key={day.date}>
+                    <td>{formatDate(day.date)}</td>
+                    <td>{day.commits.toLocaleString()}</td>
+                    <td>{day.pullRequests.toLocaleString()}</td>
+                    <td>{day.issuesOpened.toLocaleString()}</td>
+                    <td>{day.total.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.section_header}>
+          <h3>Contribution graph</h3>
+        </div>
+        <div className={styles.contribution_graph}>
+          {!imageError ? (
+            <img
+              src={`https://ghchart.rshah.org/${username}`}
+              alt={`${username}'s GitHub contribution graph`}
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            <p className={styles.error_message}>Failed to load contribution graph</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default UserActivity;

--- a/frontend/src/components/UserProfile.jsx
+++ b/frontend/src/components/UserProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../services/api';
 import UserProfileCard from './UserProfileCard';
@@ -6,6 +6,7 @@ import RepoList from './RepoList';
 import UserActivity from './UserActivity';
 import UserRanking from './UserRanking';
 import styles from '../styles/UserProfile.module.css';
+import { DEFAULT_QUEUE_METRICS, normalizeQueueMetrics } from '../utils/metrics';
 
 function UserProfile() {
   const { username } = useParams();
@@ -13,40 +14,115 @@ function UserProfile() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [refreshMessage, setRefreshMessage] = useState('');
+  const [refreshMessage, setRefreshMessage] = useState('Load the latest GitHub data whenever you need it.');
+  const [refreshMetrics, setRefreshMetrics] = useState(() => ({ ...DEFAULT_QUEUE_METRICS }));
 
-  useEffect(() => {
-    const fetchUserProfile = async () => {
+  const buildStatusMessage = useCallback((data, responseStatus) => {
+    if (!data) {
+      return 'Load the latest GitHub data whenever you need it.';
+    }
+
+    if (data.status === 'pending' || responseStatus === 202) {
+      return data.message || 'We are preparing this profile. Check back shortly.';
+    }
+
+    if (data.is_refreshing) {
+      return 'Profile data is refreshing in the background...';
+    }
+
+    if (data.is_fresh) {
+      return 'Profile data was updated recently.';
+    }
+
+    return 'Profile data may be out of date. Refresh to grab the latest stats.';
+  }, []);
+
+  const fetchUserProfile = useCallback(async ({ silent = false } = {}) => {
+    if (!username) {
+      return null;
+    }
+
+    if (!silent) {
       setLoading(true);
       setError(null);
-      try {
-        const response = await api.getUserProfile(username);
-        setUserProfile(response.data);
-        if (response.data.is_refreshing) {
-          setRefreshMessage("Profile data is refreshing in the background...");
-        }
-      } catch (err) {
+    }
+
+    try {
+      const response = await api.getUserProfile(username);
+      setUserProfile(response.data);
+      setIsRefreshing(Boolean(response.data.is_refreshing));
+      setRefreshMessage(buildStatusMessage(response.data, response.status));
+      setRefreshMetrics(normalizeQueueMetrics(response.data.refresh_metrics));
+      return response.data;
+    } catch (err) {
+      if (!silent) {
         setError(err.message || 'Failed to load user profile.');
-      } finally {
+      }
+      return null;
+    } finally {
+      if (!silent) {
         setLoading(false);
       }
-    };
+    }
+  }, [username, buildStatusMessage]);
 
+  useEffect(() => {
     fetchUserProfile();
-  }, [username]);
+  }, [fetchUserProfile]);
+
+  useEffect(() => {
+    if (!username) {
+      return undefined;
+    }
+
+    const shouldPoll = Boolean(
+      userProfile?.is_refreshing ||
+      (refreshMetrics.active ?? 0) > 0 ||
+      (refreshMetrics.queued ?? 0) > 0
+    );
+
+    if (!shouldPoll) {
+      return undefined;
+    }
+
+    const interval = setInterval(() => {
+      fetchUserProfile({ silent: true });
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [username, userProfile?.is_refreshing, refreshMetrics.active, refreshMetrics.queued, fetchUserProfile]);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
-    setRefreshMessage("Refreshing user profile...");
+    setRefreshMessage('Refreshing user profile...');
     try {
-      await api.refreshUserInfo(username);
-      setRefreshMessage("Refresh job queued successfully. Please refresh the page after a moment.");
+      const response = await api.refreshUserInfo(username);
+      setRefreshMessage(response.data?.message || 'Refresh job queued successfully. We will update the dashboard as soon as the harvest completes.');
+      const metrics = normalizeQueueMetrics(response.data?.refresh_metrics);
+      setRefreshMetrics(metrics);
+      setUserProfile((prev) => {
+        if (!prev) {
+          return prev;
+        }
+
+        if (prev.status === 'pending') {
+          return { ...prev, refresh_metrics: metrics, refresh_queued: true };
+        }
+
+        return { ...prev, is_refreshing: true, refresh_metrics: metrics, refresh_queued: true };
+      });
     } catch (err) {
-      setError(err.message || 'Failed to refresh user profile.');
+      const message = err.response?.data?.error || err.message || 'Failed to refresh user profile.';
+      setRefreshMessage(message);
     } finally {
       setIsRefreshing(false);
     }
   };
+
+  const isPending = userProfile?.status === 'pending';
+  const lastUpdatedLabel = userProfile?.last_fetched
+    ? new Date(userProfile.last_fetched).toLocaleString()
+    : 'Not available';
 
   if (loading) {
     return <div className={styles.container}><p className={styles.loading_message}>Loading user profile...</p></div>;
@@ -54,6 +130,55 @@ function UserProfile() {
 
   if (error) {
     return <div className={styles.container}><p className={styles.error_message}>Error: {error}</p></div>;
+  }
+
+  if (isPending && userProfile) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.pending_state}>
+          <h2 className={styles.pending_title}>We&apos;re fetching {username}&apos;s profile</h2>
+          <p className={styles.pending_message}>{refreshMessage}</p>
+          {userProfile.retryAfter ? (
+            <p className={styles.pending_hint}>
+              This usually takes about {userProfile.retryAfter} seconds. We&apos;ll keep this page updated automatically.
+            </p>
+          ) : null}
+          <div className={styles.status_metrics} aria-live="polite">
+            <span className={styles.metrics_heading}>Refresh queue</span>
+            <div className={styles.metrics_grid}>
+              <div className={styles.metric_item}>
+                <span className={styles.metric_value}>{refreshMetrics.active}</span>
+                <span className={styles.metric_label}>Active</span>
+              </div>
+              <div className={styles.metric_item}>
+                <span className={styles.metric_value}>{refreshMetrics.queued}</span>
+                <span className={styles.metric_label}>Queued</span>
+              </div>
+              <div className={styles.metric_item}>
+                <span className={styles.metric_value}>{refreshMetrics.delayed}</span>
+                <span className={styles.metric_label}>Delayed</span>
+              </div>
+              <div className={styles.metric_item}>
+                <span className={styles.metric_value}>{refreshMetrics.completed}</span>
+                <span className={styles.metric_label}>Completed</span>
+              </div>
+              <div className={styles.metric_item}>
+                <span className={styles.metric_value}>{refreshMetrics.failed}</span>
+                <span className={styles.metric_label}>Failed</span>
+              </div>
+            </div>
+          </div>
+          <button
+            type="button"
+            className={styles.status_button}
+            onClick={() => fetchUserProfile({ silent: true })}
+            disabled={loading}
+          >
+            Check status now
+          </button>
+        </div>
+      </div>
+    );
   }
 
   if (!userProfile) {
@@ -64,8 +189,57 @@ function UserProfile() {
     <div className={styles.container}>
       <div className={styles.report_content} id="reportContent">
         <UserProfileCard user={userProfile} />
-        
+
         <main>
+          <div className={styles.status_panel}>
+            <div className={styles.status_text}>
+              <p className={styles.status_message}>{refreshMessage}</p>
+              <p className={styles.status_meta}>Last updated: {lastUpdatedLabel}</p>
+              {userProfile.is_refreshing && (
+                <p className={styles.status_hint}>
+                  We&apos;re syncing the latest activity. Refresh this page in a few seconds to see the update.
+                </p>
+              )}
+              {(refreshMetrics.active > 0 || refreshMetrics.queued > 0) && (
+                <p className={styles.status_hint}>
+                  Queue status: {refreshMetrics.active} active • {refreshMetrics.queued} waiting • {refreshMetrics.completed} completed.
+                </p>
+              )}
+              <div className={styles.status_metrics} aria-live="polite">
+                <span className={styles.metrics_heading}>Refresh queue</span>
+                <div className={styles.metrics_grid}>
+                  <div className={styles.metric_item}>
+                    <span className={styles.metric_value}>{refreshMetrics.active}</span>
+                    <span className={styles.metric_label}>Active</span>
+                  </div>
+                  <div className={styles.metric_item}>
+                    <span className={styles.metric_value}>{refreshMetrics.queued}</span>
+                    <span className={styles.metric_label}>Queued</span>
+                  </div>
+                  <div className={styles.metric_item}>
+                    <span className={styles.metric_value}>{refreshMetrics.delayed}</span>
+                    <span className={styles.metric_label}>Delayed</span>
+                  </div>
+                  <div className={styles.metric_item}>
+                    <span className={styles.metric_value}>{refreshMetrics.completed}</span>
+                    <span className={styles.metric_label}>Completed</span>
+                  </div>
+                  <div className={styles.metric_item}>
+                    <span className={styles.metric_value}>{refreshMetrics.failed}</span>
+                    <span className={styles.metric_label}>Failed</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              className={styles.status_button}
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? 'Queuing refresh…' : 'Refresh profile'}
+            </button>
+          </div>
           <div className={styles.github_profile_status}>
           <UserActivity username={username} />
           </div>

--- a/frontend/src/components/UserProfileCard.jsx
+++ b/frontend/src/components/UserProfileCard.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import styles from '../styles/UserProfileCard.module.css';
 
 function UserProfileCard({ user }) {
+  const social = user?.social || {};
+  const hasSocialLinks = Object.keys(social).length > 0 || Boolean(user?.website);
+
   return (
     <aside className={styles.github_profile}>
       <div className={styles.profile_avatar}>
@@ -38,15 +41,15 @@ function UserProfileCard({ user }) {
           <span className={styles.label}>Following</span>
         </div>
       </div>
-      {user.social && Object.keys(user.social).length > 0 && (
+      {hasSocialLinks && (
         <div className={styles.profile_social_media}>
-          {user.social.twitter && (
-            <a href={`https://twitter.com/${user.social.twitter}`} className={styles.social_link} target="_blank" rel="noopener noreferrer">
+          {social.twitter && (
+            <a href={`https://twitter.com/${social.twitter}`} className={styles.social_link} target="_blank" rel="noopener noreferrer">
               <i className="fab fa-twitter"></i>
             </a>
           )}
-          {user.social.linkedin && (
-            <a href={`https://linkedin.com/in/${user.social.linkedin}`} className={styles.social_link} target="_blank" rel="noopener noreferrer">
+          {social.linkedin && (
+            <a href={`https://linkedin.com/in/${social.linkedin}`} className={styles.social_link} target="_blank" rel="noopener noreferrer">
               <i className="fab fa-linkedin"></i>
             </a>
           )}

--- a/frontend/src/components/UserRanking.jsx
+++ b/frontend/src/components/UserRanking.jsx
@@ -1,28 +1,122 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import api from '../services/api';
 import styles from '../styles/UserRanking.module.css';
 
-function UserRanking() {
+function formatDate(value) {
+  if (!value) return 'Unknown';
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toLocaleString();
+}
+
+function UserRanking({ username }) {
+  const [ranking, setRanking] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchRanking = useCallback(async () => {
+    if (!username) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.getUserRanking(username);
+      setRanking(response.data);
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to load ranking.');
+      setRanking(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [username]);
+
+  const handleRecalculate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await api.calculateUserRanking(username);
+      await fetchRanking();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to recalculate ranking.');
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRanking();
+  }, [fetchRanking]);
+
   return (
     <div className={styles.github_profile_ranking}>
-      <h2>Ranking on the same location:</h2>
-      <div className={styles.repo_detail_item}>
-        <i className="fas fa-clock"></i>
-        Last Update: 2 days ago
+      <div className={styles.ranking_header}>
+        <h2>Ranking</h2>
+        <button
+          type="button"
+          className={styles.refresh_button}
+          onClick={handleRecalculate}
+          disabled={loading}
+        >
+          <i className="fas fa-sync"></i> Refresh ranking
+        </button>
       </div>
-      <div className={styles.github_profile_commit_rank}>
-        <h2>Commit Ranking</h2>
-        <div className={styles.rank_info}>
-          <span className={styles.rank}>#125</span>
-          <span className={styles.label}>Global Rank</span>
+
+      {loading && <p className={styles.loading_message}>Loading ranking...</p>}
+      {error && !loading && <p className={styles.error_message}>Error: {error}</p>}
+
+      {!loading && !error && ranking && (
+        <>
+          <div className={styles.repo_detail_item}>
+            <i className="fas fa-clock"></i>
+            Last update: {formatDate(ranking.lastCalculated)}
+          </div>
+
+          <div className={styles.rank_summary}>
+            <div className={styles.rank_info}>
+              <span className={styles.rank}>#{ranking.globalRank ?? '—'}</span>
+              <span className={styles.label}>Global Rank</span>
+            </div>
+            <div className={styles.rank_info}>
+              <span className={styles.rank}>#{ranking.countryRank ?? '—'}</span>
+              <span className={styles.label}>{ranking.country || 'No country detected'}</span>
+            </div>
+          </div>
+
+          <div className={styles.ranking_metrics}>
+            <div className={styles.metric_card}>
+              <span className={styles.metric_label}>Score</span>
+              <span className={styles.metric_value}>{ranking.score ?? 0}</span>
+            </div>
+            <div className={styles.metric_card}>
+              <span className={styles.metric_label}>Followers</span>
+              <span className={styles.metric_value}>{ranking.followers ?? 0}</span>
+            </div>
+            <div className={styles.metric_card}>
+              <span className={styles.metric_label}>Public repos</span>
+              <span className={styles.metric_value}>{ranking.publicRepos ?? 0}</span>
+            </div>
+            <div className={styles.metric_card}>
+              <span className={styles.metric_label}>Total commits</span>
+              <span className={styles.metric_value}>{ranking.totalCommits ?? 0}</span>
+            </div>
+            <div className={styles.metric_card}>
+              <span className={styles.metric_label}>Total contributions</span>
+              <span className={styles.metric_value}>{ranking.totalContributions ?? 0}</span>
+            </div>
+          </div>
+        </>
+      )}
+
+      {!loading && !error && !ranking && (
+        <div className={styles.empty_state}>
+          <p>No ranking data yet. Trigger a refresh to calculate it.</p>
+          <button
+            type="button"
+            className={styles.refresh_button}
+            onClick={handleRecalculate}
+            disabled={loading}
+          >
+            <i className="fas fa-chart-line"></i> Calculate ranking
+          </button>
         </div>
-      </div>
-      <div className={styles.github_profile_contribution_rank}>
-        <h2>Contribution Ranking</h2>
-        <div className={styles.rank_info}>
-          <span className={styles.rank}>Top 1%</span>
-          <span className={styles.label}>of contributors</span>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -8,10 +8,14 @@ const getUserProfile = (username) => api.get(`/user/${username}`);
 const getUserRepos = (username, page, per_page) => api.get(`/user/${username}/repos?page=${page}&per_page=${per_page}`);
 const getUserActivity = (username) => api.get(`/user/${username}/activity`);
 const refreshUserInfo = (username) => api.post(`/user/${username}/refresh`);
+const getUserRanking = (username) => api.get(`/ranking/user/${username}`);
+const calculateUserRanking = (username) => api.post(`/ranking/calculate/${username}`);
 
 export default {
   getUserProfile,
   getUserRepos,
   getUserActivity,
   refreshUserInfo,
+  getUserRanking,
+  calculateUserRanking,
 };

--- a/frontend/src/styles/Navbar.module.css
+++ b/frontend/src/styles/Navbar.module.css
@@ -47,6 +47,11 @@
   .nav_link:hover {
     color: var(--primary);
   }
+
+  .nav_link_active {
+    color: var(--primary);
+    font-weight: 600;
+  }
   /* Small devices (landscape phones, less than 768px) */
   @media (max-width: 768px) {
     .nav_links {

--- a/frontend/src/styles/RepoList.module.css
+++ b/frontend/src/styles/RepoList.module.css
@@ -25,6 +25,12 @@
     color: var(--text-secondary);
   }
 
+  .repo_stats span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
   .lang_dot {
     display: inline-block;
     width: 8px;
@@ -91,6 +97,17 @@
       gap: 0.5rem;
       color: var(--text-secondary);
       font-size: 0.875rem;
+    }
+
+    .repo_detail_link {
+      color: var(--primary);
+      text-decoration: none;
+      word-break: break-word;
+    }
+
+    .repo_detail_link:hover,
+    .repo_detail_link:focus {
+      text-decoration: underline;
     }
 
     .repo_dates {

--- a/frontend/src/styles/StaticPage.module.css
+++ b/frontend/src/styles/StaticPage.module.css
@@ -1,0 +1,115 @@
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 6rem 2rem 4rem;
+  color: var(--text-primary);
+}
+
+.page_header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page_title {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.page_lead {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.section {
+  margin-bottom: 3rem;
+}
+
+.section_card {
+  background: var(--bg-card);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+  border: 1px solid var(--border-color);
+}
+
+.section_title {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.section_body {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.highlight_grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight_card {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 0.9rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  box-shadow: var(--card-shadow);
+}
+
+.highlight_card_title {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.highlight_card_body {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.contact_list {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.contact_item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--text-secondary);
+}
+
+.contact_label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.contact_link {
+  color: var(--primary);
+  word-break: break-word;
+  transition: var(--transition);
+}
+
+.contact_link:hover {
+  color: var(--primary-dark);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 5.5rem 1.5rem 3rem;
+  }
+
+  .page_title {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 5rem 1.25rem 3rem;
+  }
+}

--- a/frontend/src/styles/UserActivity.module.css
+++ b/frontend/src/styles/UserActivity.module.css
@@ -1,139 +1,168 @@
-/* 5.7 Status Grid */
-.status_grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); /* Flexible grid columns */
-  gap: 1rem;
-  margin-top: 1rem;
+.activity_container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.status_item {
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section_header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section_meta {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.summary_grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary_card {
   background: rgba(255, 255, 255, 0.05);
-  padding: 1rem;
-  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.summary_label {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.summary_value {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.summary_helper {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.breakdown_grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.metric_card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric_label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric_value {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.metric_helper {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.table_wrapper {
+  overflow-x: auto;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.activity_table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 500px;
+}
+
+.activity_table th,
+.activity_table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.activity_table thead {
+  background: rgba(255, 255, 255, 0.05);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.activity_table tbody tr:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.activity_table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.empty_state {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  color: var(--text-secondary);
   text-align: center;
 }
 
-/* 5.8 Language List */
-.language_list {
-  display: grid;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-.language_item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.lang_color {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-
-.lang_percent {
-  margin-left: auto;
-  color: var(--text-secondary);
-  font-size: 0.875rem;
-}
-
-/* ==========================================================================
-  Additional Styles
-  ========================================================================== */
-/* Calendar Heatmap */
-.contribution_cell:hover {
-  stroke: #ffffff33;
-  stroke-width: 1px;
-}
-
-#activityHeatmap {
-  overflow-x: auto; /* Enable horizontal scroll for heatmap if content overflows */
-  margin-top: 1rem;
-}
-
-canvas {
-  max-width: 100%;
-  margin: 1rem 0;
-}
-
-/* Languages and Stats Headers */
-.languages_header, .section_header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.info_tooltip {
-  color: var(--text-secondary);
-  cursor: help;
-  font-size: 0.875rem;
-}
-
-.language_block {
-  margin-bottom: 1rem;
-}
-
-.language_info {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
-}
-
-.lang_bar_bg {
-  width: 100%;
-  height: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-  overflow: hidden; /* Ensure bar doesn't overflow background */
-}
-
-.lang_bar {
-  height: 100%;
-  border-radius: 4px;
-  transition: width 0.3s ease; /* Smooth width transition for language bars */
-}
-
-.lang_name {
-  flex: 1; /* Language name takes available space */
-}
-
-.lang_percent {
-  color: var(--text-secondary);
-  font-size: 0.875rem;
-  white-space: nowrap; /* Prevent percentage from wrapping */
-}
-
-/* Streak Chart */
-#streakChart {
-  margin-top: 1.5rem;
-}
-
-.streak_info {
-  display: grid;
-  grid-template-columns: 1fr 1fr; /* Two columns for streak info */
-  gap: 1rem;
-  margin: 1rem 0;
-}
-
-/* Contribution Graph */
 .contribution_graph {
-  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
 }
 
-/* ==========================================================================
-  9. Responsive Design
-  ========================================================================== */
+.contribution_graph img {
+  width: 100%;
+  max-width: 600px;
+}
 
-/* Small devices (landscape phones, less than 768px) */
+.loading_message,
+.error_message {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 1rem 1.5rem;
+}
+
+.error_message {
+  color: #ff6b6b;
+}
+
 @media (max-width: 768px) {
-  .status_grid {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); /* Adjust status grid columns on smaller screens */
+  .section_header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .streak_info {
-    grid-template-columns: 1fr; /* Stack streak info on smaller screens */
+  .summary_value {
+    font-size: 1.5rem;
   }
 }

--- a/frontend/src/styles/UserProfile.module.css
+++ b/frontend/src/styles/UserProfile.module.css
@@ -1,4 +1,8 @@
 /* 5.4 Report Content */
+.container {
+  padding: 6rem 2rem 3rem;
+}
+
 .report_content {
   display: grid;
   grid-template-columns: 300px 1fr; /* Sidebar and main content layout */
@@ -19,6 +23,128 @@ main {
   display: grid;
   gap: 2rem;
   box-sizing: border-box;
+}
+
+.status_panel {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: var(--bg-card);
+  border-radius: 1rem;
+  padding: 1.75rem 2rem;
+  box-shadow: var(--card-shadow);
+  border: 1px solid var(--border-color);
+  flex-wrap: wrap;
+}
+
+.status_text {
+  flex: 1 1 260px;
+}
+
+.status_message {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.status_meta {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.status_hint {
+  margin-top: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.status_metrics {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.metrics_heading {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metrics_grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 0.75rem;
+}
+
+.metric_item {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.metric_value {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.metric_label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+.status_button {
+  background: var(--primary);
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: var(--transition);
+  font-weight: 600;
+}
+
+.status_button:hover {
+  background: var(--primary-dark);
+}
+
+.status_button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.pending_state {
+  background: var(--bg-card);
+  border-radius: 1rem;
+  padding: 2.5rem 2rem;
+  box-shadow: var(--card-shadow);
+  border: 1px solid var(--border-color);
+  max-width: 720px;
+  margin: 4rem auto 0;
+  text-align: center;
+}
+
+.pending_title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.pending_message {
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+}
+
+.pending_hint {
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
 }
 
 .github_profile_status {
@@ -42,6 +168,14 @@ main {
   main {
     grid-template-columns: 1fr; /* Stack main content on extra small screens */
     padding: 1rem; /* Adjust padding */
+  }
+
+  .status_panel {
+    padding: 1.5rem;
+  }
+
+  .metrics_grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/frontend/src/styles/UserRanking.module.css
+++ b/frontend/src/styles/UserRanking.module.css
@@ -8,12 +8,116 @@
 
 .ranking_header {
   margin-bottom: 1.5rem;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .ranking_header h2 {
   font-size: 1.5rem;
   margin-bottom: 0.5rem;
+}
+
+.refresh_button {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  transition: var(--transition);
+}
+
+.refresh_button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.refresh_button:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.loading_message,
+.error_message {
+  margin: 1rem 0;
+  font-size: 0.95rem;
+}
+
+.error_message {
+  color: #ff6b6b;
+}
+
+.repo_detail_item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.rank_summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.rank_info {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.rank {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.label {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.ranking_metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.metric_card {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.metric_label {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.metric_value {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.empty_state {
+  text-align: center;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
 }
 
 .ranking_list {
@@ -92,8 +196,23 @@
     padding: 1.5rem; /* Reduce padding on smaller screens */
   }
 
+  .ranking_header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
   .ranking_header h2 {
     font-size: 1.3rem; /* Slightly smaller header on small screens */
+    margin-bottom: 0;
+  }
+
+  .rank_summary {
+    flex-direction: column;
+  }
+
+  .ranking_metrics {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 
   .ranking_item {
@@ -124,6 +243,10 @@
 @media (max-width: 576px) {
   .github_profile_ranking {
     padding: 1rem; /* Even smaller padding on extra small screens */
+  }
+
+  .ranking_metrics {
+    grid-template-columns: 1fr;
   }
 
   .ranking_header h2 {

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,0 +1,97 @@
+export const DEFAULT_QUEUE_METRICS = {
+  queued: 0,
+  active: 0,
+  delayed: 0,
+  completed: 0,
+  failed: 0,
+};
+
+export function normalizeQueueMetrics(metrics) {
+  const base = { ...DEFAULT_QUEUE_METRICS };
+  if (!metrics || typeof metrics !== 'object') {
+    return base;
+  }
+
+  return {
+    queued: Number.isFinite(metrics.queued) ? metrics.queued : base.queued,
+    active: Number.isFinite(metrics.active) ? metrics.active : base.active,
+    delayed: Number.isFinite(metrics.delayed) ? metrics.delayed : base.delayed,
+    completed: Number.isFinite(metrics.completed) ? metrics.completed : base.completed,
+    failed: Number.isFinite(metrics.failed) ? metrics.failed : base.failed,
+  };
+}
+
+export function formatRepoDate(value) {
+  if (!value) {
+    return 'Unknown';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Unknown';
+  }
+
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatRepoSize(size) {
+  if (typeof size !== 'number' || size <= 0) {
+    return 'Unknown size';
+  }
+
+  return `${size.toLocaleString()} KB`;
+}
+
+export function calculateActivityMetrics(data = {}) {
+  const dailyActivity = Array.isArray(data.dailyActivity) ? data.dailyActivity : [];
+
+  const totals = {
+    commits: data.totals?.commits ?? 0,
+    pullRequests: data.totals?.pullRequests ?? 0,
+    issuesOpened: data.totals?.issuesOpened ?? 0,
+  };
+
+  const totalContributions = data.totalContributions ?? 0;
+  const daysTracked = data.daysTracked ?? dailyActivity.length;
+
+  const computeTotal = (entry) => {
+    if (typeof entry?.total === 'number') {
+      return entry.total;
+    }
+
+    return (entry?.commits ?? 0)
+      + (entry?.pullRequests ?? entry?.pull_requests ?? 0)
+      + (entry?.issuesOpened ?? entry?.issues_opened ?? 0);
+  };
+
+  const activeDays = data.activeDays ?? dailyActivity.filter((entry) => computeTotal(entry) > 0).length;
+
+  const averages = {
+    perDay: data.averages?.perDay ?? (daysTracked ? totalContributions / daysTracked : 0),
+    perActiveDay: data.averages?.perActiveDay ?? (activeDays ? totalContributions / activeDays : 0),
+  };
+
+  const normalizedActivity = dailyActivity.map((entry) => ({
+    date: entry.date,
+    commits: entry.commits ?? 0,
+    pullRequests: entry.pullRequests ?? entry.pull_requests ?? 0,
+    issuesOpened: entry.issuesOpened ?? entry.issues_opened ?? 0,
+    total: computeTotal(entry),
+  }));
+
+  return {
+    totalContributions,
+    totals,
+    currentStreak: data.currentStreak ?? 0,
+    longestStreak: data.longestStreak ?? 0,
+    lastActivityDate: data.lastActivityDate ?? null,
+    daysTracked,
+    activeDays,
+    averages,
+    dailyActivity: normalizedActivity,
+  };
+}

--- a/frontend/tests/metrics.test.js
+++ b/frontend/tests/metrics.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_QUEUE_METRICS,
+  normalizeQueueMetrics,
+  calculateActivityMetrics,
+  formatRepoDate,
+  formatRepoSize,
+} from '../src/utils/metrics.js';
+
+test('normalizeQueueMetrics returns defaults when input is empty', () => {
+  const result = normalizeQueueMetrics();
+  assert.deepEqual(result, DEFAULT_QUEUE_METRICS);
+});
+
+test('normalizeQueueMetrics coerces numeric fields safely', () => {
+  const result = normalizeQueueMetrics({ queued: 3, active: '2', failed: null });
+  assert.equal(result.queued, 3);
+  assert.equal(result.active, DEFAULT_QUEUE_METRICS.active);
+  assert.equal(result.failed, DEFAULT_QUEUE_METRICS.failed);
+});
+
+test('calculateActivityMetrics aggregates totals and streak inputs', () => {
+  const metrics = calculateActivityMetrics({
+    totals: { commits: 4, pullRequests: 2, issuesOpened: 1 },
+    totalContributions: 7,
+    dailyActivity: [
+      { date: '2024-05-05', commits: 2, pull_requests: 1, issues_opened: 0 },
+      { date: '2024-05-04', commits: 0, pull_requests: 0, issues_opened: 1 },
+    ],
+  });
+
+  assert.equal(metrics.totalContributions, 7);
+  assert.equal(metrics.totals.commits, 4);
+  assert.equal(metrics.dailyActivity.length, 2);
+  assert.equal(metrics.dailyActivity[0].total, 3);
+  assert.equal(metrics.averages.perDay, 3.5);
+});
+
+test('formatRepoDate falls back to Unknown on invalid input', () => {
+  assert.equal(formatRepoDate(null), 'Unknown');
+  assert.equal(formatRepoDate('not-a-date'), 'Unknown');
+});
+
+test('formatRepoSize formats positive values and guards invalid numbers', () => {
+  assert.match(formatRepoSize(2048), /2.?048 KB/);
+  assert.equal(formatRepoSize(-10), 'Unknown size');
+});

--- a/my-backend-app/.env.example
+++ b/my-backend-app/.env.example
@@ -1,0 +1,24 @@
+NODE_ENV=development
+
+# Server
+PORT=3000
+
+# Database (MySQL)
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=github_insights
+DB_SSL_CA_PATH=
+DB_SSL_REJECT_UNAUTHORIZED=true
+
+# GitHub authentication
+# Comma-separated list of personal access tokens. Leave blank to run with anonymous access limits.
+GITHUB_TOKENS=
+
+# Redis cache
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_USERNAME=
+REDIS_PASSWORD=
+REDIS_TLS=false

--- a/my-backend-app/README.md
+++ b/my-backend-app/README.md
@@ -45,42 +45,43 @@ A robust backend API service for collecting, processing, and serving GitHub user
 
 ### Environment Setup
 
-1. Clone the repository:
+1. Install dependencies and prepare a local environment file:
 ```bash
-git clone https://github.com/EL-HOUSS-BRAHIM/github-api.git
-cd github-api
-```
-
-2. Copy the example environment file:
-```bash
+npm install
 cp .env.example .env
 ```
 
-3. Configure your environment variables in `.env`:
-```
-PORT=3000
-DB_HOST=localhost
-DB_USER=your_db_user
-DB_PASSWORD=your_db_password
-DB_NAME=github_data
-GITHUB_TOKEN=your_github_token
-REDIS_HOST=localhost
-REDIS_PORT=6379
-```
+2. Configure your environment variables in `.env`:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | HTTP port used by the Express API |
+| `DB_HOST` | `127.0.0.1` | MySQL host name |
+| `DB_PORT` | `3306` | MySQL port |
+| `DB_USER` | `root` | Database user for the ingestion schema |
+| `DB_PASSWORD` | _(blank)_ | Password for `DB_USER` |
+| `DB_NAME` | `github_insights` | Database name used by Sequelize |
+| `DB_SSL_CA_PATH` | _(blank)_ | Optional absolute path to a CA certificate when connecting over TLS |
+| `DB_SSL_REJECT_UNAUTHORIZED` | `true` | Set to `false` to skip certificate validation in non-production environments |
+| `GITHUB_TOKENS` | _(blank)_ | Comma separated list of GitHub personal access tokens used for rate-limit rotation |
+| `REDIS_HOST` | `127.0.0.1` | Redis hostname |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_USERNAME` | _(blank)_ | Optional username when Redis ACLs are enabled |
+| `REDIS_PASSWORD` | _(blank)_ | Redis password when authentication is required |
+| `REDIS_TLS` | `false` | Set to `true` to enable TLS connections to Redis |
 
 ### Installation
 
-1. Install dependencies:
+Install dependencies:
 ```bash
 npm install
 ```
 
-2. Start the services using Docker:
-```bash
-docker-compose up -d
-```
+If you prefer Docker, the included `docker-compose.yml` spins up MySQL and Redis. Otherwise, provision the services manually and point the environment variables to them.
 
-3. Run the application:
+### Running locally
+
+Start the API with hot reload:
 ```bash
 npm run dev
 ```
@@ -101,19 +102,11 @@ Access the Swagger documentation at http://localhost:3000/api-docs
 
 ## Development
 
-Run the development server with hot reload:
-```bash
-npm run dev
-```
+### Testing
 
-Run the worker process:
+Run the Jest test suite:
 ```bash
-no need
-```
-
-Clear Redis cache:
-```bash
-no need
+npm test
 ```
 
 ## Docker Support

--- a/my-backend-app/package.json
+++ b/my-backend-app/package.json
@@ -52,5 +52,11 @@
     "nodemon": "^3.1.0",
     "sequelize-cli": "^6.6.2",
     "supertest": "^6.3.4"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/tests/**/*.test.js"
+    ]
   }
 }

--- a/my-backend-app/src/config/index.js
+++ b/my-backend-app/src/config/index.js
@@ -1,23 +1,66 @@
 require('dotenv').config();
 const fs = require('fs');
+const path = require('path');
+
+function readCACertificate(filePath) {
+  if (!filePath) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    console.warn(`Database CA file not found at ${resolvedPath}. Continuing without SSL CA.`);
+    return null;
+  }
+
+  try {
+    return fs.readFileSync(resolvedPath, 'utf8');
+  } catch (error) {
+    console.warn('Failed to read database CA file. Continuing without SSL CA.', error.message);
+    return null;
+  }
+}
+
+function buildSSLConfig() {
+  const ca = readCACertificate(process.env.DB_SSL_CA_PATH);
+  if (!ca) {
+    return undefined;
+  }
+
+  return {
+    ca,
+    rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false',
+  };
+}
+
+const parsedPort = Number(process.env.DB_PORT) || 3306;
+const parsedRedisPort = Number(process.env.REDIS_PORT) || 6379;
+
+const tokensEnv = process.env.GITHUB_TOKENS || '';
+const githubTokens = tokensEnv
+  .split(',')
+  .map(token => token.trim())
+  .filter(Boolean);
+
+if (tokensEnv && githubTokens.length === 0) {
+  console.warn('GITHUB_TOKENS is defined but no valid tokens were parsed.');
+}
 
 module.exports = {
-  port: process.env.PORT || 3000,
+  port: Number(process.env.PORT) || 3000,
   db: {
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    name: process.env.DB_NAME,
-    ssl: {
-      ca: fs.readFileSync(process.env.DB_SSL_CA_PATH), // Read the CA certificate
-      rejectUnauthorized: true, // Ensure SSL is required
-    },
+    host: process.env.DB_HOST || 'localhost',
+    port: parsedPort,
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || '',
+    name: process.env.DB_NAME || 'github_insights',
+    ssl: buildSSLConfig(),
   },
-  githubTokens: process.env.GITHUB_TOKENS.split(','), // Split the tokens into an array
+  githubTokens,
   redis: {
-    host: process.env.REDIS_HOST,
-    port: process.env.REDIS_PORT,
-    password: process.env.REDIS_PASSWORD, // If your Redis instance has a password
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parsedRedisPort,
+    password: process.env.REDIS_PASSWORD || undefined,
+    tls: process.env.REDIS_TLS === 'true' ? {} : undefined,
   },
 };

--- a/my-backend-app/src/config/redis.js
+++ b/my-backend-app/src/config/redis.js
@@ -1,17 +1,25 @@
 const Redis = require('ioredis');
 const config = require('./index');
 
-// Create a Redis client instance using the connection string
-const redisClient = new Redis({
+const redisOptions = {
   host: config.redis.host,
   port: config.redis.port,
-  password: config.redis.password,
-  username: 'default',
-  tls: {}, // Enable TLS/SSL
-  retryStrategy: (times) => {
-    return Math.min(times * 50, 2000);
-  }
-});
+  retryStrategy: (times) => Math.min(times * 50, 2000),
+};
+
+if (config.redis.password) {
+  redisOptions.password = config.redis.password;
+}
+
+if (process.env.REDIS_USERNAME) {
+  redisOptions.username = process.env.REDIS_USERNAME;
+}
+
+if (config.redis.tls) {
+  redisOptions.tls = config.redis.tls;
+}
+
+const redisClient = new Redis(redisOptions);
 
 // Handle connection errors gracefully
 redisClient.on('error', (err) => {

--- a/my-backend-app/src/controllers/rankingController.js
+++ b/my-backend-app/src/controllers/rankingController.js
@@ -31,6 +31,8 @@ async function calculateUserRanking(req, res, next) {
         countryRank: ranking.country_rank,
         totalCommits: ranking.total_commits,
         totalContributions: ranking.total_contributions,
+        followers: ranking.followers,
+        publicRepos: ranking.public_repos,
         lastCalculated: ranking.last_calculated_at
       }
     });
@@ -55,7 +57,19 @@ async function getUserRanking(req, res, next) {
       throw new APIError(404, 'Ranking not found');
     }
 
-    return res.json(ranking);
+    return res.json({
+      username: user.username,
+      location: user.location,
+      country: ranking.country,
+      score: ranking.score,
+      globalRank: ranking.global_rank,
+      countryRank: ranking.country_rank,
+      totalCommits: ranking.total_commits,
+      totalContributions: ranking.total_contributions,
+      followers: ranking.followers,
+      publicRepos: ranking.public_repos,
+      lastCalculated: ranking.last_calculated_at,
+    });
   } catch (error) {
     console.error('Error fetching user ranking:', error);
     return next(error);

--- a/my-backend-app/src/controllers/user.js
+++ b/my-backend-app/src/controllers/user.js
@@ -4,6 +4,102 @@ const reportService = require('../services/report');
 const { validateUsername, validatePagination } = require('../utils/validation');
 const { APIError } = require('../utils/errors');
 const redisClient = require('../config/redis');
+const { deleteKeysByPattern } = require('../utils/cache');
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_QUEUE_METRICS = {
+  queued: 0,
+  active: 0,
+  delayed: 0,
+  completed: 0,
+  failed: 0,
+};
+
+function toUtcDayMs(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function normalizeActivityRecord(activity) {
+  const date = activity.date instanceof Date
+    ? activity.date.toISOString().split('T')[0]
+    : activity.date;
+
+  const commits = activity.commits || 0;
+  const pullRequests = activity.pull_requests || activity.pullRequests || 0;
+  const issuesOpened = activity.issues_opened || activity.issuesOpened || 0;
+
+  return {
+    date,
+    commits,
+    pullRequests,
+    issuesOpened,
+    total: commits + pullRequests + issuesOpened,
+  };
+}
+
+function calculateStreaks(dailyActivity) {
+  const contributions = dailyActivity
+    .filter(day => day.total > 0)
+    .map(day => toUtcDayMs(day.date))
+    .sort((a, b) => a - b);
+
+  if (contributions.length === 0) {
+    return { currentStreak: 0, longestStreak: 0 };
+  }
+
+  let longest = 1;
+  let streak = 1;
+
+  for (let i = 1; i < contributions.length; i += 1) {
+    const diffDays = Math.round((contributions[i] - contributions[i - 1]) / DAY_IN_MS);
+    if (diffDays === 1) {
+      streak += 1;
+    } else if (diffDays > 1) {
+      streak = 1;
+    }
+
+    if (streak > longest) {
+      longest = streak;
+    }
+  }
+
+  const today = toUtcDayMs(new Date());
+  const mostRecent = contributions[contributions.length - 1];
+  const diffFromToday = Math.round((today - mostRecent) / DAY_IN_MS);
+
+  let currentStreak = 0;
+  if (diffFromToday <= 1) {
+    currentStreak = 1;
+    let index = contributions.length - 1;
+
+    while (index > 0) {
+      const gap = Math.round((contributions[index] - contributions[index - 1]) / DAY_IN_MS);
+      if (gap === 1) {
+        currentStreak += 1;
+        index -= 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return { currentStreak, longestStreak: Math.max(longest, currentStreak) };
+}
+
+function normalizeQueueMetrics(counts) {
+  if (!counts || typeof counts !== 'object') {
+    return { ...DEFAULT_QUEUE_METRICS };
+  }
+
+  return {
+    queued: typeof counts.waiting === 'number' ? counts.waiting : DEFAULT_QUEUE_METRICS.queued,
+    active: typeof counts.active === 'number' ? counts.active : DEFAULT_QUEUE_METRICS.active,
+    delayed: typeof counts.delayed === 'number' ? counts.delayed : DEFAULT_QUEUE_METRICS.delayed,
+    completed: typeof counts.completed === 'number' ? counts.completed : DEFAULT_QUEUE_METRICS.completed,
+    failed: typeof counts.failed === 'number' ? counts.failed : DEFAULT_QUEUE_METRICS.failed,
+  };
+}
 
 /**
  * @description Get user profile
@@ -16,11 +112,19 @@ async function getUserProfile(req, res, next) {
   try {
     // Find user in database
     const user = await User.findOne({ where: { username } });
-    
+
+    let refreshMetrics = { ...DEFAULT_QUEUE_METRICS };
+    try {
+      const queueCounts = await harvesterQueue.getJobCounts();
+      refreshMetrics = normalizeQueueMetrics(queueCounts);
+    } catch (metricsError) {
+      console.error('Failed to retrieve queue metrics:', metricsError);
+    }
+
     // Check if user exists and data is fresh
     if (user && !user.is_fetching) {
-      // Convert last_fetched to Date object if it isn't already  
-      const lastFetchedDate = user.last_fetched instanceof Date 
+      // Convert last_fetched to Date object if it isn't already
+      const lastFetchedDate = user.last_fetched instanceof Date
         ? user.last_fetched 
         : new Date(user.last_fetched);
       
@@ -32,7 +136,8 @@ async function getUserProfile(req, res, next) {
           ...user.toJSON(),
           data_age: timeSinceLastFetch,
           is_fresh: true,
-          last_fetched: lastFetchedDate.toISOString()
+          last_fetched: lastFetchedDate.toISOString(),
+          refresh_metrics: refreshMetrics,
         });
       }
     }
@@ -46,6 +151,10 @@ async function getUserProfile(req, res, next) {
         jobId: `harvest-${username}`,
         removeOnComplete: true
       });
+      refreshMetrics = {
+        ...refreshMetrics,
+        queued: refreshMetrics.queued + 1,
+      };
     }
 
     // Return stale data with refresh status if available
@@ -54,7 +163,8 @@ async function getUserProfile(req, res, next) {
         ...user.toJSON(),
         is_fresh: false,
         is_refreshing: true,
-        refresh_queued: true
+        refresh_queued: true,
+        refresh_metrics: refreshMetrics,
       });
     }
 
@@ -62,7 +172,8 @@ async function getUserProfile(req, res, next) {
       status: 'pending',
       message: 'User data is being fetched. Please try again in a few moments.',
       retryAfter: 5,
-      username
+      username,
+      refresh_metrics: refreshMetrics,
     });
 
   } catch (error) {
@@ -83,65 +194,88 @@ async function getUserRepos(req, res, next) {
     return next(new APIError(400, 'Invalid username format'));
   }
 
+  if (!validatePagination(page, per_page)) {
+    return next(new APIError(400, 'Invalid pagination parameters'));
+  }
+
+  const pageNumber = parseInt(page, 10);
+  const perPageNumber = parseInt(per_page, 10);
+
   try {
-    // Cache key includes sort parameters
-    const cacheKey = `user:${username}:repos:${page}:${per_page}`;
+    const cacheKey = `user:${username}:repos:${pageNumber}:${perPageNumber}`;
     const cachedRepos = await redisClient.get(cacheKey);
-    
+
     if (cachedRepos) {
       return res.json(JSON.parse(cachedRepos));
     }
 
     const user = await User.findOne({
       where: { username },
-      include: [{
-        model: Repository,
-        attributes: [
-          'name',
-          'description',
-          'stars',
-          'forks', 
-          'issues',
-          'last_commit',
-          'commit_count',
-          'pull_request_count',
-          'topics'
-        ],
-        order: [
-          ['stars', 'DESC'],
-          ['name', 'ASC']
-        ]
-      }]
+      attributes: ['id']
     });
 
     if (!user) {
       return next(new APIError(404, 'User not found'));
     }
 
-    // Get total count and paginate
-    const total = await Repository.count({
-      where: { user_id: user.id }
+    const offset = (pageNumber - 1) * perPageNumber;
+
+    const { count, rows } = await Repository.findAndCountAll({
+      where: { user_id: user.id },
+      order: [
+        ['stars', 'DESC'],
+        ['name', 'ASC']
+      ],
+      limit: perPageNumber,
+      offset,
+      attributes: [
+        'name',
+        'description',
+        'stars',
+        'forks',
+        'issues',
+        'last_commit',
+        'commit_count',
+        'pull_request_count',
+        'topics',
+        'primary_language',
+        'license',
+        'size',
+        'watchers',
+        'homepage',
+        'default_branch',
+        'source_created_at',
+        'source_updated_at'
+      ]
     });
 
-    const offset = (page - 1) * per_page;
-    const repos = user.Repositories
-      .slice(offset, offset + per_page)
-      .map(repo => ({
-        name: repo.name,
-        description: repo.description,
-        stars: repo.stars,
-        forks: repo.forks,
-        issues: repo.issues,
-        last_commit: repo.last_commit,
-        commit_count: repo.commit_count,
-        pull_request_count: repo.pull_request_count,
-        topics: repo.topics || []
-      }));
+    const repos = rows.map((repo) => {
+      const plain = typeof repo.toJSON === 'function' ? repo.toJSON() : repo;
+      return {
+        name: plain.name,
+        description: plain.description,
+        stars: plain.stars,
+        forks: plain.forks,
+        issues: plain.issues,
+        last_commit: plain.last_commit,
+        commit_count: plain.commit_count,
+        pull_request_count: plain.pull_request_count,
+        topics: Array.isArray(plain.topics) ? plain.topics : [],
+        language: plain.primary_language || null,
+        license: plain.license || null,
+        size: typeof plain.size === 'number' ? plain.size : null,
+        watchers: typeof plain.watchers === 'number' ? plain.watchers : null,
+        homepage: plain.homepage || null,
+        default_branch: plain.default_branch || null,
+        created_at: plain.source_created_at || null,
+        updated_at: plain.source_updated_at || null,
+      };
+    });
 
     const response = {
-      total_count: total,
-      page: parseInt(page),
-      per_page: parseInt(per_page),
+      total_count: count,
+      page: pageNumber,
+      per_page: perPageNumber,
       repos
     };
 
@@ -182,17 +316,38 @@ async function getUserActivity(req, res, next) {
       throw new APIError(404, 'User not found');
     }
 
-    // Process activities with proper date handling
-    const activities = user.Activities.map(activity => ({
-      date: activity.date instanceof Date ? activity.date.toISOString().split('T')[0] : activity.date,
-      commits: activity.commits || 0,
-      pull_requests: activity.pull_requests || 0,
-      issues_opened: activity.issues_opened || 0
-    }));
+    const dailyActivity = user.Activities
+      .map(normalizeActivityRecord)
+      .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+    const totals = dailyActivity.reduce((acc, day) => ({
+      commits: acc.commits + day.commits,
+      pullRequests: acc.pullRequests + day.pullRequests,
+      issuesOpened: acc.issuesOpened + day.issuesOpened,
+    }), { commits: 0, pullRequests: 0, issuesOpened: 0 });
+
+    const totalContributions = totals.commits + totals.pullRequests + totals.issuesOpened;
+    const daysTracked = dailyActivity.length;
+    const activeDays = dailyActivity.filter(day => day.total > 0).length;
+    const averages = {
+      perDay: daysTracked ? totalContributions / daysTracked : 0,
+      perActiveDay: activeDays ? totalContributions / activeDays : 0,
+    };
+
+    const { currentStreak, longestStreak } = calculateStreaks(dailyActivity);
+    const lastActivityDate = dailyActivity.length > 0 ? dailyActivity[0].date : null;
 
     return res.json({
       username: user.username,
-      activities: activities
+      totals,
+      totalContributions,
+      currentStreak,
+      longestStreak,
+      lastActivityDate,
+      daysTracked,
+      activeDays,
+      averages,
+      dailyActivity,
     });
 
   } catch (error) {
@@ -271,8 +426,16 @@ async function refreshUserInfo(req, res, next) {
 
     // Clear cache
     await redisClient.del(`user:${username}:profile`);
-    await redisClient.del(`user:${username}:repos:*`);
-    
+    await deleteKeysByPattern(`user:${username}:repos:*`);
+
+    let refreshMetrics = { ...DEFAULT_QUEUE_METRICS };
+    try {
+      const counts = await harvesterQueue.getJobCounts();
+      refreshMetrics = normalizeQueueMetrics(counts);
+    } catch (metricsError) {
+      console.error('Failed to retrieve queue metrics before queuing refresh:', metricsError);
+    }
+
     // Queue refresh job
     await harvesterQueue.add(
       'refresh-user',
@@ -284,11 +447,18 @@ async function refreshUserInfo(req, res, next) {
       }
     );
 
+    refreshMetrics = {
+      ...refreshMetrics,
+      queued: (refreshMetrics.queued ?? DEFAULT_QUEUE_METRICS.queued) + 1,
+    };
+
     return res.status(202).json({
       status: 'refreshing',
       message: 'User refresh job queued successfully',
       username,
-      retryAfter: 5
+      retryAfter: 5,
+      refresh_metrics: refreshMetrics,
+      refresh_queued: true,
     });
 
   } catch (error) {

--- a/my-backend-app/src/models/Repository.js
+++ b/my-backend-app/src/models/Repository.js
@@ -28,6 +28,14 @@ const Repository = sequelize.define('Repository', {
     type: DataTypes.JSON, // Store topics as JSON array
     allowNull: true,
   },
+  primary_language: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  license: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
   stars: {
     type: DataTypes.INTEGER,
     allowNull: false,
@@ -59,6 +67,32 @@ const Repository = sequelize.define('Repository', {
     type: DataTypes.INTEGER,
     allowNull: false,
     defaultValue: 0
+  },
+  size: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: 0,
+  },
+  watchers: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: 0,
+  },
+  homepage: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  default_branch: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  source_created_at: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  source_updated_at: {
+    type: DataTypes.DATE,
+    allowNull: true,
   },
 }, {
   // Optional: Add indexes for faster querying

--- a/my-backend-app/src/models/UserRanking.js
+++ b/my-backend-app/src/models/UserRanking.js
@@ -29,6 +29,16 @@ const UserRanking = sequelize.define('UserRanking', {
     type: DataTypes.INTEGER,
     defaultValue: 0,
   },
+  followers: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: null,
+  },
+  public_repos: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: null,
+  },
   global_rank: {
     type: DataTypes.INTEGER,
     allowNull: true,

--- a/my-backend-app/src/routes/user.js
+++ b/my-backend-app/src/routes/user.js
@@ -55,17 +55,33 @@ router.get('/:username/repos', userController.getUserRepos);
 
 // GET /api/user/:username/activity
 /**
- * Retrieves user's GitHub activity history
- * 
+ * Retrieves a GitHub user's recent activity with aggregate statistics
+ *
  * @param {string} username - GitHub username
  * @returns {Object} Activity data
  * {
  *   username: string,
- *   activities: [{
+ *   totals: {
+ *     commits: number,
+ *     pullRequests: number,
+ *     issuesOpened: number
+ *   },
+ *   totalContributions: number,
+ *   currentStreak: number,
+ *   longestStreak: number,
+ *   lastActivityDate: string | null,
+ *   daysTracked: number,
+ *   activeDays: number,
+ *   averages: {
+ *     perDay: number,
+ *     perActiveDay: number
+ *   },
+ *   dailyActivity: [{
  *     date: string (YYYY-MM-DD),
  *     commits: number,
- *     pull_requests: number,
- *     issues_opened: number
+ *     pullRequests: number,
+ *     issuesOpened: number,
+ *     total: number
  *   }]
  * }
  */

--- a/my-backend-app/src/utils/cache.js
+++ b/my-backend-app/src/utils/cache.js
@@ -1,0 +1,25 @@
+const redisClient = require('../config/redis');
+
+async function deleteKeysByPattern(pattern) {
+  if (!pattern) {
+    throw new Error('A pattern is required to delete keys from Redis.');
+  }
+
+  let cursor = '0';
+  let totalDeleted = 0;
+
+  do {
+    const [nextCursor, keys] = await redisClient.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+    if (Array.isArray(keys) && keys.length > 0) {
+      const deleted = await redisClient.del(...keys);
+      totalDeleted += deleted;
+    }
+    cursor = nextCursor;
+  } while (cursor !== '0');
+
+  return totalDeleted;
+}
+
+module.exports = {
+  deleteKeysByPattern,
+};

--- a/my-backend-app/tests/apiContracts.test.js
+++ b/my-backend-app/tests/apiContracts.test.js
@@ -1,0 +1,547 @@
+const request = require('supertest');
+
+const mockRedisClient = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  quit: jest.fn(),
+};
+
+const mockHarvesterQueue = {
+  add: jest.fn(),
+  getJobs: jest.fn(),
+  getJobCounts: jest.fn(),
+  clean: jest.fn(),
+  close: jest.fn(),
+};
+
+const mockCacheUtils = {
+  deleteKeysByPattern: jest.fn(),
+};
+
+const mockUserModel = { findOne: jest.fn() };
+const mockUserRankingModel = { findOne: jest.fn() };
+const mockActivityModel = { sum: jest.fn(), findAll: jest.fn() };
+const mockRepositoryModel = {
+  count: jest.fn(),
+  findAndCountAll: jest.fn(),
+};
+
+const mockRankingService = {
+  updateUserRanking: jest.fn(),
+  updateRankings: jest.fn(),
+};
+
+const mockGithubService = {
+  searchUsersByLocation: jest.fn(),
+  getUserProfile: jest.fn(),
+};
+
+jest.mock('../src/scheduler', () => ({}));
+jest.mock('../src/config/redis', () => mockRedisClient);
+jest.mock('../src/queues/harvester', () => mockHarvesterQueue);
+jest.mock('../src/utils/cache', () => mockCacheUtils);
+jest.mock('../src/models', () => ({
+  User: mockUserModel,
+  UserRanking: mockUserRankingModel,
+  Activity: mockActivityModel,
+  Repository: mockRepositoryModel,
+}));
+jest.mock('../src/services/ranking', () => mockRankingService);
+jest.mock('../src/services/github', () => mockGithubService);
+
+const app = require('../src/app');
+const redisClient = require('../src/config/redis');
+const harvesterQueue = require('../src/queues/harvester');
+const cacheUtils = require('../src/utils/cache');
+const rankingService = require('../src/services/ranking');
+const { User, UserRanking } = require('../src/models');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockUserModel.findOne.mockReset();
+  mockUserRankingModel.findOne.mockReset();
+  mockActivityModel.sum.mockReset();
+  mockActivityModel.findAll.mockReset();
+  mockRepositoryModel.count.mockReset();
+  mockRepositoryModel.findAndCountAll.mockReset();
+
+  mockRedisClient.get.mockReset();
+  mockRedisClient.set.mockReset();
+  mockRedisClient.del.mockReset();
+  mockRedisClient.quit.mockReset();
+  if (mockRedisClient.scan?.mockReset) {
+    mockRedisClient.scan.mockReset();
+    mockRedisClient.scan.mockResolvedValue(['0', []]);
+  }
+
+  mockHarvesterQueue.add.mockReset();
+  mockHarvesterQueue.getJobs.mockReset();
+  mockHarvesterQueue.getJobCounts.mockReset();
+  mockHarvesterQueue.clean.mockReset();
+  mockHarvesterQueue.close.mockReset();
+
+  mockCacheUtils.deleteKeysByPattern.mockReset();
+  mockRankingService.updateUserRanking.mockReset();
+  mockRankingService.updateRankings.mockReset();
+
+  mockRedisClient.get.mockResolvedValue(null);
+  mockRedisClient.set.mockResolvedValue(null);
+  mockRedisClient.del.mockResolvedValue(1);
+  mockRedisClient.quit.mockResolvedValue(null);
+  mockRedisClient.scan = mockRedisClient.scan || jest.fn().mockResolvedValue(['0', []]);
+
+  mockHarvesterQueue.add.mockResolvedValue(undefined);
+  mockHarvesterQueue.getJobs.mockResolvedValue([]);
+  mockHarvesterQueue.getJobCounts.mockResolvedValue({
+    waiting: 0,
+    active: 0,
+    delayed: 0,
+    completed: 0,
+    failed: 0,
+  });
+  mockHarvesterQueue.clean.mockResolvedValue(undefined);
+  mockHarvesterQueue.close.mockResolvedValue(undefined);
+
+  mockCacheUtils.deleteKeysByPattern.mockResolvedValue(0);
+  mockRepositoryModel.findAndCountAll.mockResolvedValue({ count: 0, rows: [] });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('Ranking API', () => {
+  test('GET /api/ranking/user/:username returns ranking details', async () => {
+    const userRecord = { id: 42, username: 'octocat', location: 'San Francisco' };
+    const rankingRecord = {
+      country: 'United States',
+      score: 4120,
+      global_rank: 15,
+      country_rank: 2,
+      total_commits: 1890,
+      total_contributions: 2450,
+      followers: 875,
+      public_repos: 120,
+      last_calculated_at: '2024-05-01T12:00:00.000Z',
+    };
+
+    User.findOne.mockResolvedValue(userRecord);
+    UserRanking.findOne.mockResolvedValue(rankingRecord);
+
+    const response = await request(app).get('/api/ranking/user/octocat');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      username: 'octocat',
+      location: 'San Francisco',
+      country: 'United States',
+      score: 4120,
+      globalRank: 15,
+      countryRank: 2,
+      totalCommits: 1890,
+      totalContributions: 2450,
+      followers: 875,
+      publicRepos: 120,
+      lastCalculated: '2024-05-01T12:00:00.000Z',
+    });
+  });
+
+  test('GET /api/ranking/user/:username returns 404 when ranking is missing', async () => {
+    User.findOne.mockResolvedValue({ id: 7, username: 'missing', location: 'Paris' });
+    UserRanking.findOne.mockResolvedValue(null);
+
+    const response = await request(app).get('/api/ranking/user/missing');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Ranking not found', status: 404 });
+  });
+
+  test('GET /api/ranking/user/:username returns 404 when user is unknown', async () => {
+    User.findOne.mockResolvedValue(null);
+
+    const response = await request(app).get('/api/ranking/user/ghost');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'User not found', status: 404 });
+  });
+
+  test('POST /api/ranking/calculate/:username recalculates ranking', async () => {
+    User.findOne.mockResolvedValue({ id: 9, username: 'refetch', location: 'Berlin' });
+    mockRankingService.updateUserRanking.mockResolvedValue({
+      score: 5150,
+      global_rank: 21,
+      country_rank: 4,
+      total_commits: 2200,
+      total_contributions: 3125,
+      followers: 430,
+      public_repos: 88,
+      last_calculated_at: '2024-05-02T08:30:00.000Z',
+    });
+
+    const response = await request(app).post('/api/ranking/calculate/refetch');
+
+    expect(response.status).toBe(200);
+    expect(mockRankingService.updateUserRanking).toHaveBeenCalledWith(9);
+    expect(response.body).toEqual({
+      success: true,
+      ranking: {
+        score: 5150,
+        globalRank: 21,
+        countryRank: 4,
+        totalCommits: 2200,
+        totalContributions: 3125,
+        followers: 430,
+        publicRepos: 88,
+        lastCalculated: '2024-05-02T08:30:00.000Z',
+      },
+    });
+  });
+
+  test('POST /api/ranking/calculate/:username returns 404 when user is unknown', async () => {
+    User.findOne.mockResolvedValue(null);
+
+    const response = await request(app).post('/api/ranking/calculate/ghost');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'User not found', status: 404 });
+    expect(mockRankingService.updateUserRanking).not.toHaveBeenCalled();
+  });
+});
+
+describe('User profile API', () => {
+  test('GET /api/user/:username returns fresh profile with queue metrics', async () => {
+    const now = new Date();
+    const payload = {
+      username: 'octocat',
+      full_name: 'The Octocat',
+      is_fetching: false,
+      last_fetched: now,
+    };
+
+    mockUserModel.findOne.mockResolvedValue({
+      ...payload,
+      toJSON: () => ({
+        username: payload.username,
+        full_name: payload.full_name,
+        last_fetched: now,
+        is_fetching: payload.is_fetching,
+      }),
+    });
+
+    const response = await request(app).get('/api/user/octocat');
+
+    expect(mockUserModel.findOne).toHaveBeenCalledWith({ where: { username: 'octocat' } });
+    expect(mockHarvesterQueue.getJobCounts).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      username: 'octocat',
+      full_name: 'The Octocat',
+      is_fresh: true,
+      refresh_metrics: {
+        queued: 0,
+        active: 0,
+        delayed: 0,
+        completed: 0,
+        failed: 0,
+      },
+    });
+    expect(typeof response.body.data_age).toBe('number');
+  });
+
+  test('GET /api/user/:username queues refresh for stale data and returns metrics', async () => {
+    const staleDate = new Date(Date.now() - (48 * 60 * 60 * 1000));
+    mockUserModel.findOne.mockResolvedValue({
+      username: 'octocat',
+      full_name: 'The Octocat',
+      is_fetching: false,
+      last_fetched: staleDate,
+      toJSON: () => ({
+        username: 'octocat',
+        full_name: 'The Octocat',
+        is_fetching: false,
+        last_fetched: staleDate,
+      }),
+    });
+    mockHarvesterQueue.getJobs.mockResolvedValueOnce([]);
+
+    const response = await request(app).get('/api/user/octocat');
+
+    expect(mockHarvesterQueue.add).toHaveBeenCalledWith(
+      { username: 'octocat' },
+      expect.objectContaining({ jobId: 'harvest-octocat', removeOnComplete: true })
+    );
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      username: 'octocat',
+      is_refreshing: true,
+      refresh_queued: true,
+      refresh_metrics: expect.objectContaining({
+        queued: 1,
+      }),
+    });
+  });
+
+  test('GET /api/user/:username returns 202 for unknown user with queue metrics', async () => {
+    mockUserModel.findOne.mockResolvedValue(null);
+    mockHarvesterQueue.getJobs.mockResolvedValueOnce([]);
+
+    const response = await request(app).get('/api/user/new-user');
+
+    expect(mockHarvesterQueue.add).toHaveBeenCalledWith(
+      { username: 'new-user' },
+      expect.objectContaining({ jobId: 'harvest-new-user', removeOnComplete: true })
+    );
+    expect(response.status).toBe(202);
+    expect(response.body).toEqual({
+      status: 'pending',
+      message: 'User data is being fetched. Please try again in a few moments.',
+      retryAfter: 5,
+      username: 'new-user',
+      refresh_metrics: expect.objectContaining({
+        queued: 1,
+      }),
+    });
+  });
+});
+
+describe('User refresh API', () => {
+  test('POST /api/user/:username/refresh clears cache and queues job', async () => {
+    mockHarvesterQueue.getJobCounts.mockResolvedValueOnce({
+      waiting: 2,
+      active: 1,
+      delayed: 0,
+      completed: 5,
+      failed: 1,
+    });
+
+    const response = await request(app).post('/api/user/octocat/refresh');
+
+    expect(response.status).toBe(202);
+    expect(redisClient.del).toHaveBeenCalledWith('user:octocat:profile');
+    expect(cacheUtils.deleteKeysByPattern).toHaveBeenCalledWith('user:octocat:repos:*');
+    expect(harvesterQueue.getJobCounts).toHaveBeenCalledTimes(1);
+    expect(harvesterQueue.add).toHaveBeenCalledWith(
+      'refresh-user',
+      { username: 'octocat' },
+      expect.objectContaining({
+        attempts: 3,
+        removeOnComplete: true,
+        jobId: expect.stringMatching(/^refresh-octocat-/),
+      })
+    );
+    expect(response.body).toEqual({
+      status: 'refreshing',
+      message: 'User refresh job queued successfully',
+      username: 'octocat',
+      retryAfter: 5,
+      refresh_metrics: {
+        queued: 3,
+        active: 1,
+        delayed: 0,
+        completed: 5,
+        failed: 1,
+      },
+      refresh_queued: true,
+    });
+  });
+});
+
+describe('User repositories API', () => {
+  test('GET /api/user/:username/repos returns paginated repositories', async () => {
+    User.findOne.mockResolvedValue({ id: 11, username: 'octocat' });
+    mockRepositoryModel.findAndCountAll.mockResolvedValue({
+      count: 3,
+      rows: [
+        {
+          toJSON: () => ({
+            name: 'awesome-lib',
+            description: 'Useful helpers',
+            stars: 50,
+            forks: 10,
+            issues: 2,
+            last_commit: '2024-04-10T00:00:00.000Z',
+            commit_count: 120,
+            pull_request_count: 30,
+            topics: ['javascript', 'tooling'],
+            primary_language: 'JavaScript',
+            license: 'MIT',
+            size: 2048,
+            watchers: 75,
+            homepage: 'https://example.dev',
+            default_branch: 'main',
+            source_created_at: '2022-01-02T10:00:00.000Z',
+            source_updated_at: '2024-04-09T09:30:00.000Z',
+          }),
+        },
+        {
+          toJSON: () => ({
+            name: 'side-project',
+            description: null,
+            stars: 5,
+            forks: 1,
+            issues: 0,
+            last_commit: null,
+            commit_count: 12,
+            pull_request_count: 0,
+            topics: undefined,
+            primary_language: null,
+            license: null,
+            size: null,
+            watchers: null,
+            homepage: null,
+            default_branch: null,
+            source_created_at: null,
+            source_updated_at: null,
+          }),
+        },
+      ],
+    });
+
+    const response = await request(app).get('/api/user/octocat/repos?page=1&per_page=2');
+
+    expect(response.status).toBe(200);
+    expect(User.findOne).toHaveBeenCalledWith({ where: { username: 'octocat' }, attributes: ['id'] });
+    expect(mockRepositoryModel.findAndCountAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { user_id: 11 },
+        limit: 2,
+        offset: 0,
+        order: [
+          ['stars', 'DESC'],
+          ['name', 'ASC'],
+        ],
+      })
+    );
+    expect(response.body).toEqual({
+      total_count: 3,
+      page: 1,
+      per_page: 2,
+      repos: [
+        {
+          name: 'awesome-lib',
+          description: 'Useful helpers',
+          stars: 50,
+          forks: 10,
+          issues: 2,
+          last_commit: '2024-04-10T00:00:00.000Z',
+          commit_count: 120,
+          pull_request_count: 30,
+          topics: ['javascript', 'tooling'],
+          language: 'JavaScript',
+          license: 'MIT',
+          size: 2048,
+          watchers: 75,
+          homepage: 'https://example.dev',
+          default_branch: 'main',
+          created_at: '2022-01-02T10:00:00.000Z',
+          updated_at: '2024-04-09T09:30:00.000Z',
+        },
+        {
+          name: 'side-project',
+          description: null,
+          stars: 5,
+          forks: 1,
+          issues: 0,
+          last_commit: null,
+          commit_count: 12,
+          pull_request_count: 0,
+          topics: [],
+          language: null,
+          license: null,
+          size: null,
+          watchers: null,
+          homepage: null,
+          default_branch: null,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+    });
+    expect(redisClient.set).toHaveBeenCalledWith(
+      'user:octocat:repos:1:2',
+      JSON.stringify(response.body),
+      'EX',
+      3600,
+    );
+  });
+
+  test('GET /api/user/:username/repos returns cached payload when available', async () => {
+    const cached = {
+      total_count: 0,
+      page: 1,
+      per_page: 10,
+      repos: [],
+    };
+    redisClient.get.mockResolvedValueOnce(JSON.stringify(cached));
+
+    const response = await request(app).get('/api/user/octocat/repos');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(cached);
+    expect(User.findOne).not.toHaveBeenCalled();
+    expect(mockRepositoryModel.findAndCountAll).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/user/:username/repos validates pagination input', async () => {
+    const response = await request(app).get('/api/user/octocat/repos?page=0&per_page=500');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Invalid pagination parameters', status: 400 });
+    expect(redisClient.get).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/user/:username/repos returns 404 when user is unknown', async () => {
+    User.findOne.mockResolvedValue(null);
+
+    const response = await request(app).get('/api/user/octocat/repos?page=1&per_page=5');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'User not found', status: 404 });
+    expect(mockRepositoryModel.findAndCountAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('User activity API', () => {
+  test('GET /api/user/:username/activity returns aggregated metrics', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-05T10:00:00.000Z'));
+
+    User.findOne.mockResolvedValue({
+      username: 'octocat',
+      Activities: [
+        { date: '2024-05-04', commits: 2, pull_requests: 1, issues_opened: 0 },
+        { date: '2024-05-03', commits: 0, pull_requests: 0, issues_opened: 1 },
+        { date: '2024-05-01', commits: 5, pull_requests: 0, issues_opened: 0 },
+      ],
+    });
+
+    const response = await request(app).get('/api/user/octocat/activity');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      username: 'octocat',
+      totals: {
+        commits: 7,
+        pullRequests: 1,
+        issuesOpened: 1,
+      },
+      totalContributions: 9,
+      daysTracked: 3,
+      activeDays: 3,
+      averages: {
+        perDay: 3,
+        perActiveDay: 3,
+      },
+      currentStreak: 2,
+      longestStreak: 2,
+      lastActivityDate: '2024-05-04',
+    });
+
+    expect(response.body.dailyActivity).toEqual([
+      { date: '2024-05-04', commits: 2, pullRequests: 1, issuesOpened: 0, total: 3 },
+      { date: '2024-05-03', commits: 0, pullRequests: 0, issuesOpened: 1, total: 1 },
+      { date: '2024-05-01', commits: 5, pullRequests: 0, issuesOpened: 0, total: 5 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the refresh endpoint to capture queue metrics before enqueueing and return a normalized metrics payload to the client
- update the API contract test to validate the richer refresh response
- teach the profile UI to handle pending profile responses, surface live queue metrics, and show social links when only a website is available

## Testing
- `cd my-backend-app && npm test`
- `cd frontend && npm run build`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d3bf51a0d483289b6b01846e4db3d3